### PR TITLE
Fixed dead links under "Tutorials".

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 
 ## Tutorials
 
-- [Getting Started](https://dropwizard.github.io/dropwizard/getting-started.html)
-- [Official docs](http://www.dropwizard.io/manual/index.html)
-- [Dropwizard internals](http://www.dropwizard.io/manual/internals.html)
+- [Getting Started](http://www.dropwizard.io/0.9.2/docs/getting-started.html)
+- [Official docs](http://www.dropwizard.io/0.9.2/docs/manual/index.html)
+- [Dropwizard internals](http://dropwizard.github.io/dropwizard/0.9.2/docs/manual/internals.html)
 - [Dropwizard Modules Directory](http://modules.dropwizard.io/)
 
 ## Guides


### PR DESCRIPTION
Under Tutorials section, Getting Started, Official docs and Dropwizard internals led to "404 File Not Found", I updated them with links to the latest version.
